### PR TITLE
Restore the possibility to give a name to a universe in an inductive definition

### DIFF
--- a/toplevel/command.ml
+++ b/toplevel/command.ml
@@ -311,7 +311,7 @@ let interp_cstrs evdref env impls mldata arity ind =
 let sign_level env evd sign =
   fst (List.fold_right
     (fun (_,_,t as d) (lev,env) ->
-      let s = destSort (nf_evar evd (Retyping.get_type_of env evd t)) in
+      let s = destSort (nf_evar evd (Reduction.whd_betadeltaiota env (Retyping.get_type_of env evd t))) in
       let u = univ_of_sort s in
 	(Univ.sup u lev, push_rel d env))
     sign (Univ.type0m_univ,env))


### PR DESCRIPTION
In standard Coq, it is possible to define a new constant whose value is a sort, and then use this constant in inductive definitions.  This fails if the option -indices-matter is on.  The proposed patch restores this possibility.

Here is an example of program that fails without the correction.

Definition UU := Type. Inductive toto (B : UU) : UU := c (x : B).
