### PR TITLE
Make JMeq universe polymorphic.

### DIFF
--- a/theories/Logic/JMeq.v
+++ b/theories/Logic/JMeq.v
@@ -19,6 +19,8 @@ Set Implicit Arguments.
 
 Unset Elimination Schemes.
 
+Set Universe Polymorphism.
+
 Inductive JMeq (A:Type) (x:A) : forall B:Type, B -> Prop :=
     JMeq_refl : JMeq x x.
 


### PR DESCRIPTION
This fixes #33.  This does not significantly change the time it takes to
compile coq; I have:
Before:
real    63m35.413s
user    52m31.897s
sys     10m12.110s
After:
real    63m30.077s
user    52m37.605s
sys     10m15.182s

Because of this, I don't think it hurts to make the entire file universe
polymorphic.
